### PR TITLE
Feat/#13 connect watch

### DIFF
--- a/AppleJuice/AppleJuice.xcodeproj/project.pbxproj
+++ b/AppleJuice/AppleJuice.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AF72152F2C44CE80007763C6 /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF72152E2C44CE80007763C6 /* WatchConnectivity.framework */; };
+		AF7215312C44CE89007763C6 /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF7215302C44CE89007763C6 /* WatchConnectivity.framework */; };
 		AFB1DB762C294FB8008A6A2D /* AppleJuiceApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB1DB752C294FB8008A6A2D /* AppleJuiceApp.swift */; };
 		AFB1DB782C294FB8008A6A2D /* GoalHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB1DB772C294FB8008A6A2D /* GoalHistoryView.swift */; };
 		AFB1DB7A2C294FB9008A6A2D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AFB1DB792C294FB9008A6A2D /* Assets.xcassets */; };
@@ -67,6 +69,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		AF72152E2C44CE80007763C6 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.5.sdk/System/Library/Frameworks/WatchConnectivity.framework; sourceTree = DEVELOPER_DIR; };
+		AF7215302C44CE89007763C6 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
 		AFB1DB722C294FB8008A6A2D /* AppleJuice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppleJuice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AFB1DB752C294FB8008A6A2D /* AppleJuiceApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleJuiceApp.swift; sourceTree = "<group>"; };
 		AFB1DB772C294FB8008A6A2D /* GoalHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalHistoryView.swift; sourceTree = "<group>"; };
@@ -100,6 +104,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AF7215312C44CE89007763C6 /* WatchConnectivity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -107,18 +112,29 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AF72152F2C44CE80007763C6 /* WatchConnectivity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AF72152D2C44CE7F007763C6 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				AF7215302C44CE89007763C6 /* WatchConnectivity.framework */,
+				AF72152E2C44CE80007763C6 /* WatchConnectivity.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		AFB1DB692C294FB8008A6A2D = {
 			isa = PBXGroup;
 			children = (
 				AFB1DB742C294FB8008A6A2D /* AppleJuice */,
 				AFB1DB882C295987008A6A2D /* WatchAppleJuice Watch App */,
 				AFB1DB732C294FB8008A6A2D /* Products */,
+				AF72152D2C44CE7F007763C6 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};

--- a/AppleJuice/AppleJuice.xcodeproj/project.pbxproj
+++ b/AppleJuice/AppleJuice.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		AF72152F2C44CE80007763C6 /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF72152E2C44CE80007763C6 /* WatchConnectivity.framework */; };
 		AF7215312C44CE89007763C6 /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF7215302C44CE89007763C6 /* WatchConnectivity.framework */; };
+		AF7215332C44CF09007763C6 /* ConnectivityProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7215322C44CF09007763C6 /* ConnectivityProvider.swift */; };
+		AF7215352C44D022007763C6 /* ConnectivityProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7215342C44D022007763C6 /* ConnectivityProvider.swift */; };
+		AF7215372C44D433007763C6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7215362C44D433007763C6 /* AppDelegate.swift */; };
 		AFB1DB762C294FB8008A6A2D /* AppleJuiceApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB1DB752C294FB8008A6A2D /* AppleJuiceApp.swift */; };
 		AFB1DB782C294FB8008A6A2D /* GoalHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB1DB772C294FB8008A6A2D /* GoalHistoryView.swift */; };
 		AFB1DB7A2C294FB9008A6A2D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AFB1DB792C294FB9008A6A2D /* Assets.xcassets */; };
@@ -71,6 +74,9 @@
 /* Begin PBXFileReference section */
 		AF72152E2C44CE80007763C6 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.5.sdk/System/Library/Frameworks/WatchConnectivity.framework; sourceTree = DEVELOPER_DIR; };
 		AF7215302C44CE89007763C6 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
+		AF7215322C44CF09007763C6 /* ConnectivityProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityProvider.swift; sourceTree = "<group>"; };
+		AF7215342C44D022007763C6 /* ConnectivityProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityProvider.swift; sourceTree = "<group>"; };
+		AF7215362C44D433007763C6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AFB1DB722C294FB8008A6A2D /* AppleJuice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppleJuice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AFB1DB752C294FB8008A6A2D /* AppleJuiceApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleJuiceApp.swift; sourceTree = "<group>"; };
 		AFB1DB772C294FB8008A6A2D /* GoalHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalHistoryView.swift; sourceTree = "<group>"; };
@@ -157,6 +163,7 @@
 				AFB1DBC62C2EE554008A6A2D /* ViewModel */,
 				AFB1DBC52C2EE54B008A6A2D /* Model */,
 				AFB1DB752C294FB8008A6A2D /* AppleJuiceApp.swift */,
+				AF7215362C44D433007763C6 /* AppDelegate.swift */,
 				AFB1DB792C294FB9008A6A2D /* Assets.xcassets */,
 				AFB1DB7B2C294FB9008A6A2D /* Preview Content */,
 			);
@@ -226,6 +233,7 @@
 			children = (
 				AFB1DBD52C2EF810008A6A2D /* StepsManager.swift */,
 				AFB1DBF62C2FE0B3008A6A2D /* CoreDataManager.swift */,
+				AF7215322C44CF09007763C6 /* ConnectivityProvider.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -253,6 +261,7 @@
 			children = (
 				AFB1DBEA2C2FAB24008A6A2D /* AnimationViewModel.swift */,
 				AFB1DBEC2C2FDAFC008A6A2D /* MainViewModel.swift */,
+				AF7215342C44D022007763C6 /* ConnectivityProvider.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -370,12 +379,14 @@
 				AFB1DC2B2C32E6AD008A6A2D /* DailyStatusEntity+CoreDataClass.swift in Sources */,
 				AFB1DC2C2C32E6AD008A6A2D /* DailyStatusEntity+CoreDataProperties.swift in Sources */,
 				AFB1DBCA2C2EEA86008A6A2D /* CharacterType.swift in Sources */,
+				AF7215372C44D433007763C6 /* AppDelegate.swift in Sources */,
 				AFB1DBF42C2FE019008A6A2D /* PersistentController.swift in Sources */,
 				AFB1DBFD2C2FE876008A6A2D /* GoalHistoryViewModel.swift in Sources */,
 				AFB1DBF12C2FDEE2008A6A2D /* AppleJuice.xcdatamodeld in Sources */,
 				AFB1DBD32C2EF44C008A6A2D /* DailyStatus.swift in Sources */,
 				AFB1DB782C294FB8008A6A2D /* GoalHistoryView.swift in Sources */,
 				AFB1DB762C294FB8008A6A2D /* AppleJuiceApp.swift in Sources */,
+				AF7215332C44CF09007763C6 /* ConnectivityProvider.swift in Sources */,
 				AFB1DBD02C2EF013008A6A2D /* MileStone.swift in Sources */,
 				AFB1DBCD2C2EEDA8008A6A2D /* Character.swift in Sources */,
 				AFB1DBF72C2FE0B3008A6A2D /* CoreDataManager.swift in Sources */,
@@ -402,6 +413,7 @@
 				AFB1DBCE2C2EEDA8008A6A2D /* Character.swift in Sources */,
 				AFB1DBD72C2EF810008A6A2D /* StepsManager.swift in Sources */,
 				AFB1DBED2C2FDAFC008A6A2D /* MainViewModel.swift in Sources */,
+				AF7215352C44D022007763C6 /* ConnectivityProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AppleJuice/AppleJuice/AppDelegate.swift
+++ b/AppleJuice/AppleJuice/AppDelegate.swift
@@ -1,0 +1,63 @@
+//
+//  AppDelegate.swift
+//  AppleJuice
+//
+//  Created by 이종선 on 7/15/24.
+//
+
+import SwiftUI
+import WatchConnectivity
+
+class AppDelegate: NSObject, UIApplicationDelegate, WCSessionDelegate {
+    
+    var session: WCSession {
+        WCSession.default
+    }
+    
+    // 앱이 시작될때 호출되는 메서드, WatchConnectivity 세션을 설정하고 활성화
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        if WCSession.isSupported() {
+            session.delegate = self
+            session.activate()
+        }
+        return true
+    }
+    
+    // WCSession이 활성화 될때 호출되는 메서드, 세션 활성화 상태와 오류를 처리
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        if let error = error {
+            print("Session activation failed with error: \(error.localizedDescription)")
+            return
+        }
+        print("Session activated with state: \(activationState)")
+    }
+    
+    // WatchOS로부터 메서지를 수신했을 때 호출되는 메서드
+    // 앱 활성화 되어 있을때만 동작
+    func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .didReceiveWatchMessage, object: message)
+        }
+    }
+    // 앱이 활성화 되지 않았어도 다음 앱 실행시 수신 보장 
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .didReceiveWatchMessage, object: applicationContext)
+        }
+    }
+    
+    // 세션 비활성화 될때 호출되는 메서드
+    func sessionDidBecomeInactive(_ session: WCSession) {
+        
+    }
+    
+    // 세션 해제될 때 호출되는 메서드 
+    func sessionDidDeactivate(_ session: WCSession) {
+        
+    }
+}
+
+extension Notification.Name {
+    static let didReceiveWatchMessage = Notification.Name("didReceiveWatchMessage")
+}
+

--- a/AppleJuice/AppleJuice/AppleJuiceApp.swift
+++ b/AppleJuice/AppleJuice/AppleJuiceApp.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 @main
 struct AppleJuiceApp: App {
+    // @UIApplicationDelegateAdaptor를 통해 AppDelegate 생명주기 이용
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     var body: some Scene {
         WindowGroup {
             GoalHistoryView()

--- a/AppleJuice/AppleJuice/CoreData/AppleJuice.xcdatamodeld/AppleJuice.xcdatamodel/contents
+++ b/AppleJuice/AppleJuice/CoreData/AppleJuice.xcdatamodeld/AppleJuice.xcdatamodel/contents
@@ -3,7 +3,6 @@
     <entity name="DailyStatusEntity" representedClassName="DailyStatusEntity" syncable="YES">
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" attributeType="String"/>
-        <attribute name="isAcheive" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="steps" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
 </model>

--- a/AppleJuice/AppleJuice/Manager/ConnectivityProvider.swift
+++ b/AppleJuice/AppleJuice/Manager/ConnectivityProvider.swift
@@ -1,0 +1,33 @@
+//
+//  WatchConnector.swift
+//  AppleJuice
+//
+//  Created by 이종선 on 7/15/24.
+//
+
+import Foundation
+import WatchConnectivity
+
+class ConnectivityProvider: NSObject, ObservableObject {
+    
+    @Published var receivedMessage: [String: Any] = [:]
+    
+    // NotificationCenter에 Observer 등록
+    override init() {
+        super.init()
+        NotificationCenter.default.addObserver(self, selector: #selector(handleMessage(notification:)), name: .didReceiveWatchMessage, object: nil)
+    }
+    
+    // WatchOS로부터 메시지 수신시 해당 message 처리
+    @objc private func handleMessage(notification: Notification) {
+        if let message = notification.object as? [String: Any] {
+            DispatchQueue.main.async {
+                self.receivedMessage = message
+            }
+        }
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+}

--- a/AppleJuice/AppleJuice/Manager/CoreDataManager.swift
+++ b/AppleJuice/AppleJuice/Manager/CoreDataManager.swift
@@ -22,7 +22,6 @@ class CoreDataManager {
         entity.id = status.id
         entity.steps = Int16(status.steps)
         entity.createdAt = status.date
-        entity.isAcheive = status.isAchieve
 
         do{
             try mainContext.save()

--- a/AppleJuice/AppleJuice/Model/DailyStatus.swift
+++ b/AppleJuice/AppleJuice/Model/DailyStatus.swift
@@ -35,10 +35,6 @@ struct DailyStatus : Identifiable {
     
     static func from(entity: DailyStatusEntity) -> Self {
         
-        if entity.isAcheive {
-            
-        }
-        
         return DailyStatus(id: entity.id ?? "", date: entity.createdAt ?? .now, character: Character(type: .apple), steps: Int(entity.steps), mileStone: entity.isAcheive ? .tenThousand  : nil)
     }
 }

--- a/AppleJuice/AppleJuice/Model/DailyStatus.swift
+++ b/AppleJuice/AppleJuice/Model/DailyStatus.swift
@@ -13,28 +13,9 @@ struct DailyStatus : Identifiable {
     let date: Date
     var character: Character
     var steps: Int = 0
-    var mileStone: MileStone? = nil
-    var isAchieve : Bool {
-        mileStone == .tenThousand
-    }
-    
-    // MARK: 일단 모두 기본 값을 배정해 두고 이후 데이터 저장 방식, 캐릭터 지정방식에 따라 변경 가능하도록
-    init(id: String = UUID().uuidString ,date: Date = Date(), character: Character = Character(type: .apple)) {
-        self.id = id 
-        self.date = .now
-        self.character = character
-    }
-    
-    init(id: String, date: Date, character: Character, steps: Int, mileStone: MileStone?){
-        self.id = id
-        self.date = date
-        self.character = character
-        self.steps = steps
-        
-    }
     
     static func from(entity: DailyStatusEntity) -> Self {
         
-        return DailyStatus(id: entity.id ?? "", date: entity.createdAt ?? .now, character: Character(type: .apple), steps: Int(entity.steps), mileStone: entity.isAcheive ? .tenThousand  : nil)
+        return DailyStatus(id: entity.id ?? "", date: entity.createdAt ?? .now, character: Character(type: .apple), steps: Int(entity.steps))
     }
 }

--- a/AppleJuice/AppleJuice/Model/DailyStatusEntity+CoreDataProperties.swift
+++ b/AppleJuice/AppleJuice/Model/DailyStatusEntity+CoreDataProperties.swift
@@ -18,7 +18,6 @@ extension DailyStatusEntity {
 
     @NSManaged public var createdAt: Date?
     @NSManaged public var id: String?
-    @NSManaged public var isAcheive: Bool
     @NSManaged public var steps: Int16
 
 }

--- a/AppleJuice/AppleJuice/View/GoalHistoryView.swift
+++ b/AppleJuice/AppleJuice/View/GoalHistoryView.swift
@@ -10,13 +10,14 @@ import SwiftUI
 struct GoalHistoryView: View {
     
     @StateObject private var vm = GoalHistoryViewModel()
+    @StateObject private var cp = ConnectivityProvider()
     
     var body: some View {
         VStack {
             Image(systemName: "globe")
                 .imageScale(.large)
                 .foregroundStyle(.tint)
-            Text("Hello, world!")
+            Text("\(cp.receivedMessage.description)")
         }
         .padding()
     }

--- a/AppleJuice/WatchAppleJuice Watch App/View/MainView.swift
+++ b/AppleJuice/WatchAppleJuice Watch App/View/MainView.swift
@@ -45,16 +45,15 @@ struct MainView: View {
             }
             .toolbar{
                 // 정해진 mileStone이 있는 경우에만 랜더링
-                if let milestone = vm.dailyStatus.mileStone {
                     
                     ToolbarItem(placement: .topBarTrailing){
                         Button(action: {
                             
                         }, label: {
-                            Image(systemName: vm.dailyStatus.mileStone?.iconName ?? "carrot.fill")
+                            Image(systemName: "carrot.fill")
                         })
                     }
-                }
+                
 
             }
         }

--- a/AppleJuice/WatchAppleJuice Watch App/View/MainView.swift
+++ b/AppleJuice/WatchAppleJuice Watch App/View/MainView.swift
@@ -13,6 +13,7 @@ struct MainView: View {
     
     @State private var path = NavigationPath()
     @StateObject private var vm = MainViewModel()
+    @StateObject private var cp = ConnectivityProvider()
     
     var body: some View {
         
@@ -48,7 +49,7 @@ struct MainView: View {
                     
                     ToolbarItem(placement: .topBarTrailing){
                         Button(action: {
-                            
+                            cp.sendMessage(message: [ "key" : true])
                         }, label: {
                             Image(systemName: "carrot.fill")
                         })

--- a/AppleJuice/WatchAppleJuice Watch App/ViewModel/ConnectivityProvider.swift
+++ b/AppleJuice/WatchAppleJuice Watch App/ViewModel/ConnectivityProvider.swift
@@ -1,0 +1,46 @@
+//
+//  ConnectivityProvider.swift
+//  WatchAppleJuice Watch App
+//
+//  Created by 이종선 on 7/15/24.
+//
+
+import WatchConnectivity
+import SwiftUI
+
+class ConnectivityProvider: NSObject, ObservableObject, WCSessionDelegate {
+    
+    override init() {
+        super.init()
+        if WCSession.isSupported() {
+            let session = WCSession.default
+            session.delegate = self
+            session.activate()
+        }
+    }
+    
+    // 세션 활성화시 호출
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        if let error = error {
+            print("Session activation failed with error: \(error.localizedDescription)")
+            return
+        }
+        print("Session activated with state: \(activationState)")
+    }
+    
+    // message 전달
+    func sendMessage(message: [String: Any]) {
+        if WCSession.default.isReachable {
+            WCSession.default.sendMessage(message, replyHandler: nil) { error in
+                print("Error sending message: \(error.localizedDescription)")
+            }
+        } else {
+            do {
+                try WCSession.default.updateApplicationContext(message)
+            } catch {
+                print("Error updating application context: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+

--- a/AppleJuice/WatchAppleJuice Watch App/ViewModel/MainViewModel.swift
+++ b/AppleJuice/WatchAppleJuice Watch App/ViewModel/MainViewModel.swift
@@ -9,11 +9,5 @@ import Foundation
 
 class MainViewModel: ObservableObject {
     
-    @Published var dailyStatus: DailyStatus
-    
-    init() {
-        self.dailyStatus = DailyStatus()
-    }
-    
-    
+
 }


### PR DESCRIPTION
# 제목
watchOS로부터 iOS 쪽으로 메시지를 전달합니다. 

# 설명
이 PR은 다음과 같은 변경 사항을 포함합니다:
- AppDelegate를 이용해 WatchConnectivity Session을 관리합니다. 
- @main(iOS)에서 @UIApplicationDelegateAdaptor를 이용해 AppDelegate를 통한 생명주기를 관리합니다. 
- ConnectivityProvider(iOS)는 NotificationCenter를 통해 AppDelegate에서 발행한 알림을 통해 WatchOS 로부터 온 메시지를 수신합니다. 이를 핸들러를 통해 처리합니다. 
- 현재는 ConnectivityProvider(iOS) 쪽에서 단순히 메시지를 수신한다음 이를 GoalHistoryView상에 표시하고 있지만 메시지를 수신했을 때 핸들러를 통해 coreData 엔티티를 생성해서 저장합니다. 
- 새로운 엔티티를 생성할때는 해당 날짜에 대한 엔티티가 이미 있는지 먼저 확인한후 , 엔티티를 만들게 함으로써 하루에 하나의 엔티티만 있는 것을 보장하도록 합니다. 
- ConnectivityProvider(WatchOS)는 sendMessage 메서드를 통해 메시지를 전달할 수 있습니다. 
- 현재 MainView에서 ConnectivityProvider(WatchOS)를 참조해 메시지를 직접 전달하고 있지만 해당 ConnectivityProvider를 MainViewModel 계층으로 옮길 수 있습니다. 
- 메시지 전달 흐름

WatchOS 앱이 실행 중일 때, 사용자가 버튼을 눌러 메시지를 전송합니다.
sendMessage 메서드를 통해 즉시 전송을 시도합니다.

만약 iOS 앱이 활성화되어 있지 않다면 sendMessage는 실패합니다.
대신 updateApplicationContext 메서드를 사용하여 애플리케이션 컨텍스트를 업데이트합니다.
이는 iOS 앱이 다음에 실행될 때 수신됩니다.

iOS 앱이 실행될 때:
AppDelegate에서 Watch Connectivity 세션을 설정하고 활성화합니다.
세션이 활성화되면 didReceiveApplicationContext 메서드가 호출되어 이전에 WatchOS에서 보낸 애플리케이션 컨텍스트를 수신합니다.

# 관련 이슈
Closes #13

