### PR TITLE
 [#17] feat : 만보 달성 시 주스 버튼 눌렀을 때 해당 날짜를 수집, iOS 로 전송함

### DIFF
--- a/AppleJuice/WatchAppleJuice Watch App/View/MainView.swift
+++ b/AppleJuice/WatchAppleJuice Watch App/View/MainView.swift
@@ -49,7 +49,17 @@ struct MainView: View {
                     
                     ToolbarItem(placement: .topBarTrailing){
                         Button(action: {
-                            cp.sendMessage(message: [ "key" : true])
+                            //cp.sendMessage(message: [ "key" : true])
+                            
+                            //날짜 설정
+                            let currentDate = Date()
+                            let dateFormatter = DateFormatter()
+                            dateFormatter.dateFormat = "yyyy-MM-dd"
+                            let formattedDate = dateFormatter.string(from: currentDate)
+
+                            print(formattedDate)
+                            cp.sendMessage(message: [ "date" : formattedDate])
+                            
                         }, label: {
                             Image(systemName: "carrot.fill")
                         })


### PR DESCRIPTION
# 제목
만보 달성 시 주스 버튼 눌렀을 때 해당 날짜를 수집, iOS 로 전송합니다.

# 설명
이 PR은 다음과 같은 변경 사항을 포함합니다:
- MainView 의 토글버튼을 누르는 시점에 Date() 를 이용하여 날짜 정보를 가지고 옵니다.
- 날짜 정보를 문자열로 가공하여 Connectivity Provider 로 iOS 에 전송합니다.

# 관련 이슈
Closes or Ref #[17]

# 변경 사항
- MainView 의 버튼 액션 사항을 변경하였습니다.

# 검토자에게 할 말
- #11 이슈를 통해 올린 PR 에 헬스킷 관련 작업이 포함되어 있기 때문에, 해당 PR 이 머지 된 후에 이후 작업 진행이 가능할 것으로 예상됩니다.
- 날짜 정보를 이용해서 헬스킷에서 해당 날짜 정보만 가지고 오는 작업을 계획중입니다.
- [참고예정 블로그](https://appdone.tistory.com/entry/iOS-Swift-%EA%B1%B4%EA%B0%95-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0-HealthKit)