### PR TITLE
만보 달성 로직 오류에 따른 버그 수정

### DIFF
--- a/AppleJuice/AppleJuice.xcodeproj/project.pbxproj
+++ b/AppleJuice/AppleJuice.xcodeproj/project.pbxproj
@@ -339,7 +339,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1540;
-				LastUpgradeCheck = 1540;
+				LastUpgradeCheck = 1610;
 				TargetAttributes = {
 					AFB1DB712C294FB8008A6A2D = {
 						CreatedOnToolsVersion = 15.4;
@@ -564,7 +564,6 @@
 		AFB1DB812C294FB9008A6A2D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = AppleJuice/AppleJuice.entitlements;
@@ -572,7 +571,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"AppleJuice/Preview Content\"";
-				DEVELOPMENT_TEAM = K3CQFPAA9A;
+				DEVELOPMENT_TEAM = 6KQJH558XZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = AppleJuice/Info.plist;
@@ -607,7 +606,6 @@
 		AFB1DB822C294FB9008A6A2D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = AppleJuice/AppleJuice.entitlements;
@@ -615,7 +613,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"AppleJuice/Preview Content\"";
-				DEVELOPMENT_TEAM = K3CQFPAA9A;
+				DEVELOPMENT_TEAM = 6KQJH558XZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = AppleJuice/Info.plist;
@@ -657,7 +655,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"WatchAppleJuice Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = K3CQFPAA9A;
+				DEVELOPMENT_TEAM = 6KQJH558XZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "WatchAppleJuice-Watch-App-Info.plist";
@@ -694,7 +692,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"WatchAppleJuice Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = K3CQFPAA9A;
+				DEVELOPMENT_TEAM = 6KQJH558XZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "WatchAppleJuice-Watch-App-Info.plist";

--- a/AppleJuice/AppleJuice.xcodeproj/xcshareddata/xcschemes/AppleJuice.xcscheme
+++ b/AppleJuice/AppleJuice.xcodeproj/xcshareddata/xcschemes/AppleJuice.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1610"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/AppleJuice/AppleJuice.xcodeproj/xcshareddata/xcschemes/WatchAppleJuice Watch App.xcscheme
+++ b/AppleJuice/AppleJuice.xcodeproj/xcshareddata/xcschemes/WatchAppleJuice Watch App.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1610"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/AppleJuice/AppleJuice/AppDelegate.swift
+++ b/AppleJuice/AppleJuice/AppDelegate.swift
@@ -23,6 +23,15 @@ class AppDelegate: NSObject, UIApplicationDelegate, WCSessionDelegate {
         return true
     }
     
+    func applicationWillResignActive(_ application: UIApplication) {
+        saveLastLoginDate() // 앱이 액티브 상태에서 나갈때 마지막 접속 날짜를 저장
+    }
+    
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        saveLastLoginDate() // 앱이 백그라운드모드에 들어갈때 마지막 접속 날짜를 저장
+    }
+
+    
     // WCSession이 활성화 될때 호출되는 메서드, 세션 활성화 상태와 오류를 처리
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
         if let error = error {

--- a/AppleJuice/AppleJuice/AppleJuiceApp.swift
+++ b/AppleJuice/AppleJuice/AppleJuiceApp.swift
@@ -13,8 +13,6 @@ struct AppleJuiceApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     
     init() {
-        saveLastLoginDate() // 앱 실행 시 호출
-        
     }
     
     var body: some Scene {
@@ -26,10 +24,7 @@ struct AppleJuiceApp: App {
 
 // 앱이 시작될 때 마지막 접속 일자를 저장
 func saveLastLoginDate() {
-    // 현재 날짜 가져오기
     let currentDate = Date()
-    
-    // 컴포넌트 설정
     let calendar = Calendar.current
     var components = calendar.dateComponents([.year, .month, .day], from: currentDate)
     components.hour = 0

--- a/AppleJuice/AppleJuice/CoreData/PersistentController.swift
+++ b/AppleJuice/AppleJuice/CoreData/PersistentController.swift
@@ -16,13 +16,13 @@ struct PersistenceController {
         let result = PersistenceController(inMemory: true)
         let viewContext = result.container.viewContext
         
-        
         do {
             try viewContext.save()
         } catch {
             let nsError = error as NSError
             fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
         }
+        
         return result
     }()
     

--- a/AppleJuice/AppleJuice/Manager/ConnectivityProvider.swift
+++ b/AppleJuice/AppleJuice/Manager/ConnectivityProvider.swift
@@ -37,33 +37,3 @@ class ConnectivityProvider: NSObject, ObservableObject {
         NotificationCenter.default.removeObserver(self)
     }
 }
-
-//
-//
-//
-//import Foundation
-//import WatchConnectivity
-//
-//class ConnectivityProvider: NSObject, ObservableObject {
-//
-//    @Published var receivedMessage: [String: Any] = [:]
-//
-//    // NotificationCenter에 Observer 등록
-//    override init() {
-//        super.init()
-//        NotificationCenter.default.addObserver(self, selector: #selector(handleMessage(notification:)), name: .didReceiveWatchMessage, object: nil)
-//    }
-//
-//    // WatchOS로부터 메시지 수신시 해당 message 처리
-//    @objc private func handleMessage(notification: Notification) {
-//        if let message = notification.object as? [String: Any] {
-//            DispatchQueue.main.async {
-//                self.receivedMessage = message
-//            }
-//        }
-//    }
-//
-//    deinit {
-//        NotificationCenter.default.removeObserver(self)
-//    }
-//}

--- a/AppleJuice/AppleJuice/Manager/CoreDataManager.swift
+++ b/AppleJuice/AppleJuice/Manager/CoreDataManager.swift
@@ -36,7 +36,6 @@ class CoreDataManager {
         
         do{
             try mainContext.save()
-            
         } catch {
             print("Failed to save status: \(error)")
         }

--- a/AppleJuice/WatchAppleJuice Watch App/WatchAppleJuiceApp.swift
+++ b/AppleJuice/WatchAppleJuice Watch App/WatchAppleJuiceApp.swift
@@ -11,7 +11,23 @@ import SwiftUI
 struct WatchAppleJuice_Watch_AppApp: App {
     var body: some Scene {
         WindowGroup {
-            MainView(ispushed: false)
+            MainView()
         }
     }
+    
+    init() {
+        initHistory()
+    }
+}
+
+// 앱이 최초에 시작될 때 오늘의 날짜와 만보 달성 여부를 저장 (key: 날짜, value: 달성여부)
+// UserDefaults에 해당 날짜의 value 가 없으면 false로 저장
+func initHistory() {
+    if UserDefaults.standard.object(forKey: Date().toString()) == nil {
+        UserDefaults.standard.set(false, forKey: Date().toString())
+    }
+}
+
+func saveHistory() {
+    UserDefaults.standard.set(true, forKey: Date().toString())
 }


### PR DESCRIPTION
# 제목
만보 달성 로직 오류에 따른 버그 수정

# 관련 이슈
Closes or Ref #32 

# 변경 사항
- 만보 달성 이후 나타나는 오른쪽 상단 버튼을 누르지 않아도 자동으로 메인화면의 에셋이 주스로 교체됩니다.
-> 만보 달성 이후 버튼 상호작용없이 배경애셋이 바뀌도록 되어있었습니다. isStepCountsOver10000 변수를 추가하여 버튼 클릭시에 배경화면이 바뀌도록 설정하였습니다.

- 만보 걸어도 버튼이 안뜹니다. 배경화면 주스만 바뀝니다. 각종 값들의 초기화가 필요한 것으로 보입니다.
-> juiceButtonVisible 값이 걸음 수가 10,000에 도달할 때 true로 설정되는 로직이 누락되었습니다. mainView ZStack 의 onChange 메서드로 sm.stepCount가 만보를 넘으면 juiceButtonVisible이 true가 되도록 설정을 추가했습니다. + UserDefaults 를 이용하여 해당 일자에 만보가 달성되었는지를 확인, 이미 되어있는 경우에는 다시 false 가 되도록 합니다.

- 냉장고에 걸음 수 갱신이 다음날 되어도 갱신이 안됩니다. 버튼을 눌렀을 때의 값만 남아있습니다.
-> 앱의 초기화시에 마지막 접속날짜를 저장하도록 되어있었습니다;; AppDelegate 를 이용하여 앱이 액티브에서 나갈 때 (종료되거나 백그라운드모드에 들어갈때) 마지막 접속 날짜를 저장합니다.

# 검토자에게 할 말
- 이후 해피의 새로운 Asset 을 적용하고, 버튼 눌렀을 때에 축하 효과 및 냉장고 배경 애니메이션이 이어지도록 작업을 이어갈 예정입니다.
